### PR TITLE
move indicators into h2

### DIFF
--- a/src/components/Event.svelte
+++ b/src/components/Event.svelte
@@ -26,19 +26,21 @@
   <label for={`ev-check-${id}`}>
     <div class="event-header">
       <div class="event-title">
-        <h2>{name}</h2>
-        {#if initiatePointsNumber && initiatePointsCategory && showInitiatePoints}
-          <div class="initiate-points-container">
-            <div class="initiate-points-count">
-              <div>
-                {initiatePointsNumber}
-              </div>
-            </div>
-            <div class="initiate-points-category">
-              {initiatePointsCategory}
-            </div>
-          </div>
-        {/if}
+        <h2>
+          {name}
+          {#if initiatePointsNumber && initiatePointsCategory && showInitiatePoints}
+            <span class="initiate-points-container">
+              <span class="initiate-points-count">
+                <span>
+                  {initiatePointsNumber}
+                </span>
+              </span>
+              <span class="initiate-points-category">
+                {initiatePointsCategory}
+              </span>
+            </span>
+          {/if}
+        </h2>
       </div>
       <div class="event-right">
         <h4 class="datetime">{date} @ {time}</h4>
@@ -168,10 +170,12 @@
       width: inherit !important;
       align-items: flex-start !important;
     }
+  }
 
+  @media only screen and (max-width: 505px) {
     .initiate-points-container {
       margin-left: 0px !important;
-      margin-bottom: 27px;
+      margin-top: 3px;
     }
   }
 
@@ -231,29 +235,35 @@
   }
 
   .initiate-points-container {
-    margin-left: 10px;
+    /* margin-left: 10px; */
     background-color: #fff;
     border-radius: 25px;
     padding: 4px;
-    display: flex;
     flex-direction: row;
     max-height: 30px;
+    /* max-width: 100px; */
+    font-size: 1rem;
+    display: inline-block;
+    vertical-align: top;
+    /* margin-top: 3px; */
   }
 
   .initiate-points-count {
     background-color: #0f2040;
     border-radius: 25px;
     width: 20px;
-    display: flex;
     justify-content: center;
     user-select: none;
   }
-  .initiate-points-count div {
-    margin-left: -1.5px;
+  .initiate-points-count span {
+    /* margin-left: -1.5px; */
+    padding-left: 7px;
+    padding-right: 7px;
+    margin-left: -0.5px;
   }
 
   .initiate-points-category {
-    margin-left: 8px;
+    margin-left: 4px;
     color: #0f2040;
     text-transform: capitalize;
     padding-right: 6px;

--- a/src/components/Event.svelte
+++ b/src/components/Event.svelte
@@ -241,11 +241,10 @@
     padding: 4px;
     flex-direction: row;
     max-height: 30px;
-    /* max-width: 100px; */
-    font-size: 1rem;
+    font-size: 16px;
     display: inline-block;
     vertical-align: top;
-    /* margin-top: 3px; */
+    font-weight: 400;
   }
 
   .initiate-points-count {
@@ -263,7 +262,7 @@
   }
 
   .initiate-points-category {
-    margin-left: 4px;
+    margin-left: 3px;
     color: #0f2040;
     text-transform: capitalize;
     padding-right: 6px;


### PR DESCRIPTION
Moves initiate points indicators into `h2` elements so that they are considered part of the wrappable text and handled better by browsers. Please mess around with this and try to break it before we deploy!