### PR TITLE
fix calendar and bg

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,6 +1,7 @@
 body {
   font-family: "Schibsted Grotesk", Arial, Helvetica, sans-serif;
   overflow-x: hidden;
+  background-color: white;
 }
 
 .triangle:before {

--- a/src/components/Events.svelte
+++ b/src/components/Events.svelte
@@ -45,7 +45,9 @@
 </script>
 
 <div class="evcontainer">
-  {#if events2.length > 0}
+  {#if events2
+    .filter(checkDate)
+    .filter((e, i) => i < cutoffCount || (daysDiff(new Date(), e.date) <= cutoffDays && i < maxCount) || showAll).length > 0}
     <div class="initiate-points-toggler">
       <p>
         <label for="initiatepoints">Show initiate points?</label>


### PR DESCRIPTION
Correctly show no events message on the homepage instead of an empty calendar.

Set body background to white to avoid issues with some nonstandard browser themes.