### PR TITLE
Recording for ECE 408 MT2 Q1

### DIFF
--- a/src/content/StudentServices/review_sessions.ts
+++ b/src/content/StudentServices/review_sessions.ts
@@ -122,6 +122,7 @@ export const reviewSessions: Record<1 | 2 | 3, ReviewSession[]> = {
       slidesLink: "https://drive.google.com/file/d/14-E0fS7vKoI8pQpt_dFAnFow64H0MPgV/view?usp=sharing"
     },
     
+    
     {
       course: "ECE 411",
       time: "9/22, 3:00-5:30PM",
@@ -206,6 +207,7 @@ export const reviewSessions: Record<1 | 2 | 3, ReviewSession[]> = {
       course: "ECE 408",
       time: "10/13, 3:00-5:30PM",
       location: "ECEB 1002",
+      recordingLink: "https://drive.google.com/file/d/1u-PtTW4-GVHhTzOK105RBXrWvUsy9Py1/view?usp=sharing"
     },
     {
       course: "ECE 411",

--- a/src/content/StudentServices/review_sessions.ts
+++ b/src/content/StudentServices/review_sessions.ts
@@ -138,6 +138,7 @@ export const reviewSessions: Record<1 | 2 | 3, ReviewSession[]> = {
       course: "ECE 110",
       time: "10/20, 3:00-5:30PM",
       location: "ECEB 1002",
+      slidesLink: "https://docs.google.com/presentation/d/1ANp3B_RQjOAzlhKPM589kiZbGWoK8k8I4WEluFpwCq0/edit?usp=sharing"
     },
     {
       course: "ECE 120",


### PR DESCRIPTION
Added this on the MT2 deck as the dates matched.

Prev:
<img width="1440" alt="Screenshot 2024-10-13 at 18 02 08" src="https://github.com/user-attachments/assets/72e1ed97-c2ba-47a4-a6bb-e5a0489a4fc4">
